### PR TITLE
fix(setup): fix encoding error during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 #  OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys,os
+import sys,os,io
 from distutils.core import setup
 from setuptools import find_packages
 
@@ -86,7 +86,7 @@ package_data = { project_var_name + ".subproject": ["*.tohelp"],
                  project_var_name + ".languages": ["*.g4", "*.tokens"], }
 
 if os.path.exists(readme):
-    with open(readme) as f : long_description = f.read()
+    with io.open(readme, encoding='utf-8') as f : long_description = f.read()
 else:
     long_description = ""
 


### PR DESCRIPTION
Encoding error occurs during install from sources on OS X Maverick, python 3.4.2
Error Traceback :
python setup.py install
Traceback (most recent call last):
  File "setup.py", line 89, in <module>
    with open(readme) as f : long_description = f.read()
  File "/usr/local/Cellar/python3/3.4.2_1/Frameworks/Python.framework/Versions/3.4/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 0: ordinal not in range(128)

Fixed this by replacing open(readme) by io.open(readme, encoding='utf-8')
